### PR TITLE
Migrate API calls to leverage the crowdstrike-falconpy library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ setuptools-scm==6.0.1
 thehive4py==1.8.1
 urllib3~=1.24.0
 wrapt==1.12.1
+crowdstrike-falconpy>=0.5.5

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1,18 +1,11 @@
 CrowdStrike = {
-    'url': 'https://api.crowdstrike.com',
-    'token_endpoint': '/oauth2/token',
-    'stream_endpoint': '/sensors/entities/datafeed/v2',
-    'app_id': '',
-    'cid': '',
-    'secret': '',
+    'app_id': 'CrowdStrike2TH-testing',
+    'client_id': '',
+    'client_secret': '',
 }
-
-CrowdStrike['url_token'] = CrowdStrike['url'] + CrowdStrike['token_endpoint']
-CrowdStrike['url_stream'] = CrowdStrike['url'] + CrowdStrike['stream_endpoint'] + f'?appId={CrowdStrike["app_id"]}'
 
 TheHive = {
     'url': '',
     'key': '',
     'template': '',
 }
-

--- a/src/main.py
+++ b/src/main.py
@@ -8,11 +8,15 @@ def print_detect(detect):
 
 
 def main():
-    crowdstrike_api = Api(key=CrowdStrike.get("cid"), secret=CrowdStrike.get("secret"))
+
+    crowdstrike_api = Api(key=CrowdStrike.get("client_id"),
+                          secret=CrowdStrike.get("client_secret"),
+                          appId=CrowdStrike.get("appId")
+                          )
 
     detects = crowdstrike_api.get_detects()
-
-    print_detect(detects['resources'][3])
+    for detection in detects["resources"]:
+        print_detect(detection)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR performs the following:

- Removes the oauthlib import
- Adds the crowdstrike-falconpy library import
- Updates all calls to the CrowdStrike API to leverage the SDK
    - Calls to the Event Stream URL that is provided by listAvailableStreamsOAuth2 is still run through the requests library.
- Updated the API class to support appId
- Removed unnecessary endpoint variables
- Added a loop to the detections display 